### PR TITLE
refactor: use constructor initializers for better readability

### DIFF
--- a/src/plugin_manager/DefaultPluginManager.ts
+++ b/src/plugin_manager/DefaultPluginManager.ts
@@ -12,7 +12,6 @@ import type PluginRepository from "./plugin_repository/PluginRepository.ts";
 export default class DefaultPluginManager implements PluginManager {
   private readonly extensionPointRegistry: ExtensionPointRegistry;
   private readonly extensionRegistry: ExtensionRegistry;
-  private readonly pluginRepositories: Array<PluginRepository>;
   private readonly pluginRepositoriesByExtensionHandle = new Map<
     string,
     PluginRepository
@@ -29,11 +28,10 @@ export default class DefaultPluginManager implements PluginManager {
    * {@link InMemoryExtensionRegistry}
    */
   public constructor(
-    pluginRepositories: Array<PluginRepository>,
+    private readonly pluginRepositories: Array<PluginRepository>,
     extensionPointRegistry?: ExtensionPointRegistry,
     extensionRegistry?: ExtensionRegistry,
   ) {
-    this.pluginRepositories = pluginRepositories;
     this.extensionPointRegistry = extensionPointRegistry ||
       new InMemoryExtensionPointRegistry();
     this.extensionRegistry = extensionRegistry ||

--- a/src/plugin_manager/plugin_repository/UrlListPluginRepository.ts
+++ b/src/plugin_manager/plugin_repository/UrlListPluginRepository.ts
@@ -9,7 +9,6 @@ import UrlPluginSource from "./UrlPluginSource.ts";
  * When scanning for Plugins each provided URL will be used to attempt to load a Plugin and examine it.
  */
 export default class UrlListPluginRepository implements PluginRepository {
-  private readonly urls: Set<string>;
   private readonly pluginSource = new UrlPluginSource();
 
   /**
@@ -17,11 +16,10 @@ export default class UrlListPluginRepository implements PluginRepository {
    *
    * @throws *Error* if the URL set contains a non-valid URL.
    */
-  public constructor(urls: Set<string>) {
+  public constructor(private readonly urls: Set<string>) {
     if (!urls || (urls.size === 0)) {
       throw new Error(`Undefined or empty set of URLs provided`);
     }
-    this.urls = urls;
     this.urls.forEach((url) => {
       try {
         new URL(url);


### PR DESCRIPTION
Refactor constructors in `DefaultPluginManager` and `UrlListPluginRepository` to utilize parameter properties, enhancing code clarity and reducing boilerplate.