### PR TITLE
fix: plugin load error handling and update project metadata

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,10 @@
     "": {
       "name": "@flowscripter/dynamic-plugin-framework",
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "^1.2.5",
       },
       "peerDependencies": {
-        "typescript": "latest",
+        "typescript": "^5.8.2",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,15 @@
 {
   "name": "@flowscripter/dynamic-plugin-framework",
+  "description": "Dynamic plugin framework for Bun based on Javascript Modules and import() function",
+  "repository": "@flowscripter/dynamic-plugin-framework",
+  "license": "MIT",
+  "keywords": [
+    "bun",
+    "plugin",
+    "framework",
+    "dynamic",
+    "import"
+  ],
   "module": "index.ts",
   "type": "module",
   "version": "1.3.14",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@flowscripter/dynamic-plugin-framework",
   "description": "Dynamic plugin framework for Bun based on Javascript Modules and import() function",
-  "repository": "@flowscripter/dynamic-plugin-framework",
+  "homepage": "https://github.com/flowscripter/dynamic-plugin-framework#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/flowscripter/dynamic-plugin-framework.git"
+  },
   "license": "MIT",
   "keywords": [
     "bun",

--- a/src/plugin_manager/plugin_repository/UrlPluginSource.ts
+++ b/src/plugin_manager/plugin_repository/UrlPluginSource.ts
@@ -29,7 +29,9 @@ export default class UrlPluginSource {
         this.pluginsByUrl.set(url, plugin);
       }
       if (pluginLoadResult.error) {
-        throw new Error(`Failed to load plugin from ${url}: ${pluginLoadResult.error.message}`);
+        throw new Error(
+          `Failed to load plugin from ${url}: ${pluginLoadResult.error.message}`,
+        );
       }
     }
     return Promise.resolve(this.pluginsByUrl.get(url));

--- a/src/plugin_manager/plugin_repository/UrlPluginSource.ts
+++ b/src/plugin_manager/plugin_repository/UrlPluginSource.ts
@@ -28,6 +28,9 @@ export default class UrlPluginSource {
         plugin = pluginLoadResult.plugin;
         this.pluginsByUrl.set(url, plugin);
       }
+      if (pluginLoadResult.error) {
+        throw new Error(`Failed to load plugin from ${url}: ${pluginLoadResult.error.message}`);
+      }
     }
     return Promise.resolve(this.pluginsByUrl.get(url));
   }

--- a/tests/plugin_manager/plugin_repository/UrlPluginSource_test.ts
+++ b/tests/plugin_manager/plugin_repository/UrlPluginSource_test.ts
@@ -15,14 +15,14 @@ const INVALID_PLUGIN_URL = "file://" +
   );
 
 describe("UrlPluginSource Tests", () => {
-  test("Returns undefined on invalid plugin", async () => {
+  test("Throws on invalid plugin",   () => {
     const urlPluginSource = new UrlPluginSource();
 
     expect(
-      await urlPluginSource.loadPlugin(
+      urlPluginSource.loadPlugin(
         new URL(INVALID_PLUGIN_URL),
       ),
-    ).toBeUndefined();
+    ).rejects.toThrow();
   });
 
   test("Loads a plugin", async () => {

--- a/tests/plugin_manager/plugin_repository/UrlPluginSource_test.ts
+++ b/tests/plugin_manager/plugin_repository/UrlPluginSource_test.ts
@@ -15,7 +15,7 @@ const INVALID_PLUGIN_URL = "file://" +
   );
 
 describe("UrlPluginSource Tests", () => {
-  test("Throws on invalid plugin",   () => {
+  test("Throws on invalid plugin", () => {
     const urlPluginSource = new UrlPluginSource();
 
     expect(


### PR DESCRIPTION
Throw an error when a plugin fails to load and update the package.json with relevant project metadata and keywords.