### PR TITLE
feat: add /plugin subpath export for plugin authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,32 @@ terminal and a browser:
 - [Host Application](https://github.com/flowscripter/example-host-application)
 - [Host Webapp](https://github.com/flowscripter/example-host-webapp)
 
+## Imports
+
+The package provides two entry points depending on your role:
+
+**Plugin authors** only need the three plugin-side interfaces. Import from the
+`/plugin` subpath to keep the host implementation out of your module graph:
+
+```typescript
+import type {
+  Plugin,
+  ExtensionDescriptor,
+  ExtensionFactory,
+} from "@flowscripter/dynamic-plugin-framework/plugin";
+```
+
+**Host application authors** import from the main entry point, which exposes
+the full API including concrete implementations:
+
+```typescript
+import {
+  DefaultPluginManager,
+  UrlListPluginRepository,
+} from "@flowscripter/dynamic-plugin-framework";
+import type { ExtensionInfo, PluginManager } from "@flowscripter/dynamic-plugin-framework";
+```
+
 ## API
 
 The following diagram provides an overview of the `Plugin` API:
@@ -248,7 +274,7 @@ Format:
 
 Lint:
 
-`bunx oxlint index.ts src/ tests/`
+`bunx oxlint index.ts plugin.ts src/ tests/`
 
 Generate HTML API Documentation:
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   },
   "type": "module",
   "module": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./plugin": "./plugin.ts"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,0 +1,3 @@
+export type { default as ExtensionFactory } from "./src/api/plugin/ExtensionFactory.ts";
+export type { default as ExtensionDescriptor } from "./src/api/plugin/ExtensionDescriptor.ts";
+export type { default as Plugin } from "./src/api/plugin/Plugin.ts";


### PR DESCRIPTION
## Summary

- Adds `plugin.ts` as a second package entry point (`@flowscripter/dynamic-plugin-framework/plugin`) exporting only the three plugin-author interfaces: `Plugin`, `ExtensionDescriptor`, `ExtensionFactory`
- Updates `package.json` with an `exports` map (`.` for host apps, `./plugin` for plugin authors); `"module": "index.ts"` retained for tools that don't support `exports`
- Updates `README.md` with an **Imports** section documenting the two entry points and their intended audiences
- No breaking changes - `index.ts` and all existing exports are untouched

## Motivation

Plugin authors only need the three plugin-side interfaces. The previous single entry point exposed host implementation classes (`DefaultPluginManager`, `UrlListPluginRepository`) unnecessarily in the plugin module graph. The subpath export makes the separation explicit and enforced.

## Known gap

`plugin.ts` is not covered by the org-level `check-bun-source` CI action, which explicitly targets `index.ts src/ tests/`. Since `plugin.ts` contains only three `export type` re-exports the risk is negligible. A companion PR to `flowscripter/.github` would be needed to genericise that step if desired.

## Test plan

- [x] `bunx tsc --noEmit` - no type errors
- [x] `bun test` - 21 tests pass
- [x] `bunx oxlint index.ts plugin.ts src/ tests/` - no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)