### PR TITLE
chore: run dependency checks twice a week instead of daily

### DIFF
--- a/.github/workflows/check-bun-dependencies.yml
+++ b/.github/workflows/check-bun-dependencies.yml
@@ -2,7 +2,7 @@ name: check-bun-dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1,4"
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
## Summary
- Changes cron schedule from daily to twice weekly (Monday and Thursday, `0 0 * * 1,4` or `0 1 * * 1,4`)

## Test plan
- [ ] Verify the workflow runs on Monday and Thursday

🤖 Generated with [Claude Code](https://claude.com/claude-code)