### PR TITLE
feat: add build step for Node.js and TypeScript consumers

### DIFF
--- a/README/development.md
+++ b/README/development.md
@@ -4,6 +4,10 @@ Install dependencies:
 
 `bun install`
 
+Build (produces `dist/` for Node.js and TypeScript consumers; Bun uses raw source directly):
+
+`bun run build`
+
 Test:
 
 `bun test`

--- a/package.json
+++ b/package.json
@@ -15,6 +15,14 @@
     "type": "git",
     "url": "git+https://github.com/flowscripter/dynamic-plugin-framework.git"
   },
+  "files": [
+    "dist",
+    "src",
+    "index.ts",
+    "plugin.ts",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -31,19 +39,11 @@
       "default": "./dist/plugin.js"
     }
   },
-  "files": [
-    "dist",
-    "src",
-    "index.ts",
-    "plugin.ts",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "build": "bun build index.ts plugin.ts --outdir dist --target node && tsc -p tsconfig.build.json"
-  },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "bun build index.ts plugin.ts --outdir dist --target node && tsc -p tsconfig.build.json"
   },
   "dependencies": {
     "semver": "^7.8.5"

--- a/package.json
+++ b/package.json
@@ -16,10 +16,31 @@
     "url": "git+https://github.com/flowscripter/dynamic-plugin-framework.git"
   },
   "type": "module",
-  "module": "index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
-    ".": "./index.ts",
-    "./plugin": "./plugin.ts"
+    ".": {
+      "bun": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "bun": "./plugin.ts",
+      "types": "./dist/plugin.d.ts",
+      "default": "./dist/plugin.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "index.ts",
+    "plugin.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "bun build index.ts plugin.ts --outdir dist --target node && tsc -p tsconfig.build.json"
   },
   "publishConfig": {
     "access": "public"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `bun run build` script: runs `bun build index.ts plugin.ts --outdir dist --target node` then `tsc -p tsconfig.build.json`
- Add `tsconfig.build.json` extending the base config with `emitDeclarationOnly`, `declaration`, `declarationMap`, `rewriteRelativeImportExtensions`, and `outDir: dist`
- Update `package.json` with `main`, `types`, dual-entry `exports` (with `bun` condition for raw source on both `.` and `./plugin`), and `files` fields
- Update development docs with build step

Bun consumers use raw `.ts` source via the `bun` exports condition. Node.js and TypeScript consumers use `dist/index.js` / `dist/plugin.js` and corresponding `.d.ts` files. Fixes `@types/semver` missing type errors in downstream consumers running TypeDoc.

## Test plan

- [ ] `bun install && bun run build` produces `dist/index.js`, `dist/plugin.js`, `dist/index.d.ts`, `dist/plugin.d.ts`
- [ ] CI workflow runs `bun run build` before semantic-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)