### PR TITLE
fix: resolve npm/bun .cmd shims through cmd.exe on Windows in install fallback

### DIFF
--- a/src/plugin_manager/NpmPluginManager.ts
+++ b/src/plugin_manager/NpmPluginManager.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import process from "node:process";
 import { mkdir, rm } from "node:fs/promises";
 import semver from "semver";
 import BaseMarketplacePluginManager from "./BaseMarketplacePluginManager.ts";
@@ -9,6 +10,26 @@ import type VersionedPluginDescriptor from "../api/plugin_repository/VersionedPl
 import type VersionedPluginRepository from "../api/plugin_repository/VersionedPluginRepository.ts";
 import type SpawnCapable from "../api/spawn/SpawnCapable.ts";
 import type SpawnInterface from "../api/spawn/SpawnInterface.ts";
+
+/**
+ * On Windows, batch-file shims (e.g. `npm.cmd`, `bun.cmd`) cannot be launched directly via
+ * `CreateProcess` - they must be run through `cmd.exe /c`. Resolve the command through the shell
+ * in that case; leave it untouched on other platforms.
+ */
+export function resolveForPlatform(args: string[]): string[] {
+  if (process.platform !== "win32") {
+    return args;
+  }
+  const [bin, ...rest] = args;
+  if (bin === undefined) {
+    return args;
+  }
+  const resolved = Bun.which(bin) ?? bin;
+  if (!/\.(cmd|bat)$/i.test(resolved)) {
+    return [resolved, ...rest];
+  }
+  return ["cmd.exe", "/d", "/s", "/c", resolved, ...rest];
+}
 
 /**
  * {@link BaseMarketplacePluginManager} for the npm ecosystem.
@@ -76,7 +97,11 @@ export default class NpmPluginManager
       return;
     }
 
-    const proc = Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit" });
+    const proc = Bun.spawn(resolveForPlatform(args), {
+      cwd,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
       throw new Error(`Command '${args.join(" ")}' failed with exit code ${exitCode}`);

--- a/tests/plugin_manager/NpmPluginManager_test.ts
+++ b/tests/plugin_manager/NpmPluginManager_test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { mkdtemp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import NpmPluginManager from "../../src/plugin_manager/NpmPluginManager.ts";
+import process from "node:process";
+import NpmPluginManager, { resolveForPlatform } from "../../src/plugin_manager/NpmPluginManager.ts";
 import NpmPluginRepository from "../../src/plugin_manager/plugin_repository/NpmPluginRepository.ts";
 import type SearchQuery from "../../src/api/plugin_repository/SearchQuery.ts";
 import type VersionedPluginDescriptor from "../../src/api/plugin_repository/VersionedPluginDescriptor.ts";
@@ -384,6 +385,58 @@ describe("NpmPluginManager", () => {
             { installCommand: "yarn add" },
           ),
       ).toThrow("Install command binary 'yarn' not found on PATH");
+    });
+  });
+
+  describe("resolveForPlatform()", () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+      spyOn(Bun, "which").mockRestore();
+    });
+
+    it("leaves the command untouched on non-win32 platforms", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+
+      expect(resolveForPlatform(["npm", "install", "foo"])).toEqual(["npm", "install", "foo"]);
+    });
+
+    it("wraps a resolved .cmd shim through cmd.exe on win32", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      spyOn(Bun, "which").mockImplementation((binary: string) =>
+        binary === "npm" ? "C:\\Program Files\\nodejs\\npm.CMD" : null,
+      );
+
+      expect(resolveForPlatform(["npm", "install", "foo"])).toEqual([
+        "cmd.exe",
+        "/d",
+        "/s",
+        "/c",
+        "C:\\Program Files\\nodejs\\npm.CMD",
+        "install",
+        "foo",
+      ]);
+    });
+
+    it("does not wrap a resolved non-shim executable on win32", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      spyOn(Bun, "which").mockImplementation((binary: string) =>
+        binary === "bun" ? "C:\\Users\\me\\.bun\\bin\\bun.exe" : null,
+      );
+
+      expect(resolveForPlatform(["bun", "add", "foo"])).toEqual([
+        "C:\\Users\\me\\.bun\\bin\\bun.exe",
+        "add",
+        "foo",
+      ]);
+    });
+
+    it("falls back to the bare binary name on win32 if Bun.which cannot resolve it", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      spyOn(Bun, "which").mockImplementation(() => null);
+
+      expect(resolveForPlatform(["npm", "install", "foo"])).toEqual(["npm", "install", "foo"]);
     });
   });
 


### PR DESCRIPTION
## Summary
- `NpmPluginManager.runCommand()`'s `Bun.spawn` fallback (used when no `SpawnInterface` has been injected via `setSpawn()`) passed the bare `npm`/`bun` command straight to `Bun.spawn`, with no shell resolution. On Windows these resolve to `.cmd` shims, which Win32's `CreateProcess` cannot execute directly, causing the spawned process to hang until the caller's own timeout kills it.
- Added `resolveForPlatform()`: on `win32`, resolves the binary via `Bun.which` and, if it's a `.cmd`/`.bat` shim, wraps the invocation through `cmd.exe /d /s /c`. No-op on other platforms.

## Context
Found while investigating a Windows-only functional test failure in `example-cli`'s CI (`plugin:add` scenario timing out after 30s): https://github.com/flowscripter/example-cli/actions/runs/29579811637/job/87890680929

`example-cli` does inject a `SpawnInterface` (via `dynamic-cli-framework`'s `DefaultSpawnService`), so the actual runtime path hit in that failure is `DefaultSpawnService.spawn()` - fixed in a companion PR: flowscripter/dynamic-cli-framework#131. This PR fixes the identical bug in this package's own fallback path, for parity, since any consumer that doesn't inject a `SpawnInterface` would hit the same hang.

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.build.json` - clean
- [x] `bunx oxlint` on changed files - clean
- [x] `bun test` - full suite passes (103/103)
- [x] Added unit tests for `resolveForPlatform()` covering: non-win32 passthrough, `.cmd` shim wrapping, non-shim executable passthrough on win32, and `Bun.which` miss fallback

https://claude.ai/code/session_01BHouCzjk6bFtxnHDPmiocC
