### PR TITLE
feat: add FetchCapable/FetchInterface for injecting a host fetch implementation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,8 @@ export type { default as ExtensionPointRegistry } from "./src/api/registry/Exten
 export type { default as PluginInstaller } from "./src/api/plugin_installer/PluginInstaller.ts";
 export type { default as SpawnInterface, SpawnResult } from "./src/api/spawn/SpawnInterface.ts";
 export type { default as SpawnCapable } from "./src/api/spawn/SpawnCapable.ts";
+export type { default as FetchInterface } from "./src/api/fetch/FetchInterface.ts";
+export type { default as FetchCapable } from "./src/api/fetch/FetchCapable.ts";
 export { default as DefaultPluginManager } from "./src/plugin_manager/DefaultPluginManager.ts";
 export { default as UrlListPluginRepository } from "./src/plugin_manager/plugin_repository/UrlListPluginRepository.ts";
 export { default as LocalFolderPluginRepository } from "./src/plugin_manager/plugin_repository/LocalFolderPluginRepository.ts";

--- a/src/api/fetch/FetchCapable.ts
+++ b/src/api/fetch/FetchCapable.ts
@@ -1,0 +1,13 @@
+import type FetchInterface from "./FetchInterface.ts";
+
+/**
+ * Implemented by {@link PluginManager} and {@link MarketplacePluginRepository} implementations
+ * which support having their `fetch()` calls delegated to a host-supplied {@link FetchInterface}
+ * instead of fetching directly.
+ */
+export default interface FetchCapable {
+  /**
+   * Supply the {@link FetchInterface} to delegate fetch calls to.
+   */
+  setFetch(fetch: FetchInterface): void;
+}

--- a/src/api/fetch/FetchInterface.ts
+++ b/src/api/fetch/FetchInterface.ts
@@ -1,0 +1,16 @@
+/**
+ * Allows a host application to supply its own `fetch()` implementation (e.g. one which
+ * integrates with a CLI framework's shutdown handling and timeout support) instead of a
+ * repository or plugin manager calling `fetch()` directly.
+ */
+export default interface FetchInterface {
+  /**
+   * Perform a fetch request.
+   *
+   * @param input the URL to fetch.
+   * @param init standard `RequestInit` fields plus an optional `timeoutMs`.
+   *
+   * @return the `Response`. Rejects the same way native `fetch()` does.
+   */
+  fetch(input: string, init?: RequestInit & { timeoutMs?: number }): Promise<Response>;
+}

--- a/src/plugin_manager/BaseMarketplacePluginManager.ts
+++ b/src/plugin_manager/BaseMarketplacePluginManager.ts
@@ -28,7 +28,9 @@ function isFetchCapable(value: unknown): value is FetchCapable {
 export default abstract class BaseMarketplacePluginManager<
   TRemote extends MarketplacePluginRepository,
   TLocal extends VersionedPluginRepository,
-> implements MarketplacePluginManager, FetchCapable {
+>
+  implements MarketplacePluginManager, FetchCapable
+{
   private readonly pluginManager: PluginManager;
   protected fetchInterface: FetchInterface | undefined;
 

--- a/src/plugin_manager/BaseMarketplacePluginManager.ts
+++ b/src/plugin_manager/BaseMarketplacePluginManager.ts
@@ -6,7 +6,13 @@ import type ExtensionInfo from "../api/plugin_manager/ExtensionInfo.ts";
 import type PluginManager from "../api/plugin_manager/PluginManager.ts";
 import type SearchQuery from "../api/plugin_repository/SearchQuery.ts";
 import type VersionedPluginDescriptor from "../api/plugin_repository/VersionedPluginDescriptor.ts";
+import type FetchCapable from "../api/fetch/FetchCapable.ts";
+import type FetchInterface from "../api/fetch/FetchInterface.ts";
 import DefaultPluginManager from "./DefaultPluginManager.ts";
+
+function isFetchCapable(value: unknown): value is FetchCapable {
+  return typeof value === "object" && value !== null && "setFetch" in value;
+}
 
 /**
  * Abstract {@link MarketplacePluginManager} implementation.
@@ -22,8 +28,9 @@ import DefaultPluginManager from "./DefaultPluginManager.ts";
 export default abstract class BaseMarketplacePluginManager<
   TRemote extends MarketplacePluginRepository,
   TLocal extends VersionedPluginRepository,
-> implements MarketplacePluginManager {
+> implements MarketplacePluginManager, FetchCapable {
   private readonly pluginManager: PluginManager;
+  protected fetchInterface: FetchInterface | undefined;
 
   /**
    * @param remotes marketplace repositories used for search and as install sources.
@@ -39,6 +46,22 @@ export default abstract class BaseMarketplacePluginManager<
     pluginManager?: PluginManager,
   ) {
     this.pluginManager = pluginManager ?? new DefaultPluginManager([local]);
+  }
+
+  /**
+   * Supplies a host-provided {@link FetchInterface} to this manager and forwards it to its
+   * `remotes`/`local` repositories, for those which support {@link FetchCapable}.
+   */
+  public setFetch(fetchInterface: FetchInterface): void {
+    this.fetchInterface = fetchInterface;
+    for (const remote of this.remotes) {
+      if (isFetchCapable(remote)) {
+        remote.setFetch(fetchInterface);
+      }
+    }
+    if (isFetchCapable(this.local)) {
+      this.local.setFetch(fetchInterface);
+    }
   }
 
   private async *searchAsyncIterable(

--- a/src/plugin_manager/HttpPluginManager.ts
+++ b/src/plugin_manager/HttpPluginManager.ts
@@ -84,7 +84,7 @@ export default class HttpPluginManager extends BaseMarketplacePluginManager<
     if (existing) return;
 
     const bundleUrl = descriptor.pluginId;
-    const response = await fetch(bundleUrl);
+    const response = await (this.fetchInterface?.fetch ?? fetch)(bundleUrl);
     if (!response.ok) {
       throw new Error(`Failed to fetch bundle from ${bundleUrl}: ${response.statusText}`);
     }

--- a/src/plugin_manager/plugin_repository/HttpManifestPluginRepository.ts
+++ b/src/plugin_manager/plugin_repository/HttpManifestPluginRepository.ts
@@ -3,6 +3,8 @@ import type ExtensionDescriptor from "../../api/plugin/ExtensionDescriptor.ts";
 import type ExtensionEntry from "../../api/plugin_repository/ExtensionEntry.ts";
 import type VersionedPluginDescriptor from "../../api/plugin_repository/VersionedPluginDescriptor.ts";
 import type SearchQuery from "../../api/plugin_repository/SearchQuery.ts";
+import type FetchCapable from "../../api/fetch/FetchCapable.ts";
+import type FetchInterface from "../../api/fetch/FetchInterface.ts";
 import loadPlugin from "../util/PluginLoader.ts";
 
 interface RemoteManifestEntry {
@@ -22,7 +24,9 @@ interface RemoteManifestEntry {
  * it in memory. Supports free-text search across plugin name, scope, and extension point IDs.
  * Plugin bundles are downloaded and cached in `cacheFolder` when extensions are instantiated.
  */
-export default class HttpManifestPluginRepository implements MarketplacePluginRepository {
+export default class HttpManifestPluginRepository
+  implements MarketplacePluginRepository, FetchCapable
+{
   public readonly name: string;
   public readonly description?: string;
   public readonly author?: string;
@@ -30,6 +34,7 @@ export default class HttpManifestPluginRepository implements MarketplacePluginRe
 
   private readonly cacheFolder: string;
   private cachedManifest: RemoteManifestEntry[] | undefined;
+  private fetchFn: FetchInterface["fetch"] = (input, init) => fetch(input, init);
 
   public constructor({
     manifestUrl,
@@ -51,11 +56,15 @@ export default class HttpManifestPluginRepository implements MarketplacePluginRe
     this.cacheFolder = cacheFolder;
   }
 
+  public setFetch(fetchInterface: FetchInterface): void {
+    this.fetchFn = fetchInterface.fetch.bind(fetchInterface);
+  }
+
   private async fetchManifest(): Promise<RemoteManifestEntry[]> {
     if (this.cachedManifest) {
       return this.cachedManifest;
     }
-    const response = await fetch(this.url);
+    const response = await this.fetchFn(this.url);
     if (!response.ok) {
       throw new Error(`Failed to fetch manifest from ${this.url}: ${response.statusText}`);
     }
@@ -126,7 +135,7 @@ export default class HttpManifestPluginRepository implements MarketplacePluginRe
       if (!entry.extensionPoints.includes(extensionPoint)) {
         continue;
       }
-      const result = await loadPlugin(entry.bundleUrl, this.cacheFolder, this.name);
+      const result = await loadPlugin(entry.bundleUrl, this.cacheFolder, this.name, this.fetchFn);
       if (!result.isValidPlugin || !result.plugin) {
         continue;
       }
@@ -153,7 +162,12 @@ export default class HttpManifestPluginRepository implements MarketplacePluginRe
   public async getExtensionDescriptorFromExtensionEntry(
     extensionEntry: ExtensionEntry,
   ): Promise<Readonly<ExtensionDescriptor>> {
-    const result = await loadPlugin(extensionEntry.pluginId, this.cacheFolder, this.name);
+    const result = await loadPlugin(
+      extensionEntry.pluginId,
+      this.cacheFolder,
+      this.name,
+      this.fetchFn,
+    );
     if (!result.isValidPlugin || !result.plugin) {
       return Promise.reject(new Error(`Failed to load plugin from ${extensionEntry.pluginId}`));
     }

--- a/src/plugin_manager/plugin_repository/NpmjsPluginRepository.ts
+++ b/src/plugin_manager/plugin_repository/NpmjsPluginRepository.ts
@@ -3,6 +3,8 @@ import type ExtensionDescriptor from "../../api/plugin/ExtensionDescriptor.ts";
 import type ExtensionEntry from "../../api/plugin_repository/ExtensionEntry.ts";
 import type VersionedPluginDescriptor from "../../api/plugin_repository/VersionedPluginDescriptor.ts";
 import type SearchQuery from "../../api/plugin_repository/SearchQuery.ts";
+import type FetchCapable from "../../api/fetch/FetchCapable.ts";
+import type FetchInterface from "../../api/fetch/FetchInterface.ts";
 
 export interface NpmSearchQuery extends SearchQuery {
   readonly keywords?: string[];
@@ -37,7 +39,7 @@ interface NpmPackageMeta {
  * Note: extensions cannot be instantiated directly from this repository — plugins must first be
  * installed locally via {@link NpmPluginInstaller}.
  */
-export default class NpmjsPluginRepository implements MarketplacePluginRepository {
+export default class NpmjsPluginRepository implements MarketplacePluginRepository, FetchCapable {
   public readonly name: string;
   public readonly description?: string;
   public readonly author?: string;
@@ -49,6 +51,7 @@ export default class NpmjsPluginRepository implements MarketplacePluginRepositor
   private readonly authToken?: string;
   private readonly username?: string;
   private readonly password?: string;
+  private fetchFn: FetchInterface["fetch"] = (input, init) => fetch(input, init);
 
   public constructor({
     name,
@@ -81,6 +84,10 @@ export default class NpmjsPluginRepository implements MarketplacePluginRepositor
     this.authToken = authToken;
     this.username = username;
     this.password = password;
+  }
+
+  public setFetch(fetchInterface: FetchInterface): void {
+    this.fetchFn = fetchInterface.fetch.bind(fetchInterface);
   }
 
   private buildHeaders(): Headers {
@@ -118,7 +125,7 @@ export default class NpmjsPluginRepository implements MarketplacePluginRepositor
   }
 
   private async fetchPackageDoc(packageName: string): Promise<Record<string, unknown> | undefined> {
-    const response = await fetch(`${this.registryUrl}/${packageName}/latest`, {
+    const response = await this.fetchFn(`${this.registryUrl}/${packageName}/latest`, {
       headers: this.buildHeaders(),
     });
     if (!response.ok) {
@@ -139,7 +146,7 @@ export default class NpmjsPluginRepository implements MarketplacePluginRepositor
       }
     }
 
-    const response = await fetch(
+    const response = await this.fetchFn(
       `${this.registryUrl}/-/v1/search?text=${encodeURIComponent(searchText)}&size=250`,
       { headers: this.buildHeaders() },
     );

--- a/src/plugin_manager/util/PluginLoader.ts
+++ b/src/plugin_manager/util/PluginLoader.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type Plugin from "../../api/plugin/Plugin.ts";
+import type FetchInterface from "../../api/fetch/FetchInterface.ts";
 
 /**
  * Result of a {@link loadPlugin} invocation.
@@ -23,7 +24,12 @@ export interface PluginLoadResult {
   error?: Error;
 }
 
-async function getLocalUrl(remoteUrl: string, cacheFolder: string, repoName: string) {
+async function getLocalUrl(
+  remoteUrl: string,
+  cacheFolder: string,
+  repoName: string,
+  fetchFn: FetchInterface["fetch"],
+) {
   const url = new URL(remoteUrl);
   const urlPath = url.pathname;
 
@@ -37,7 +43,7 @@ async function getLocalUrl(remoteUrl: string, cacheFolder: string, repoName: str
 
   await mkdir(path.dirname(localPluginPath), { recursive: true });
 
-  const result = await fetch(remoteUrl);
+  const result = await fetchFn(remoteUrl);
 
   await Bun.write(installePluginFile, result);
 
@@ -58,6 +64,7 @@ export default async function loadPlugin(
   url: string,
   cacheFolder: string = path.join(os.homedir(), ".flowscripter", "plugin"),
   repoName: string = "default",
+  fetchFn: FetchInterface["fetch"] = fetch,
 ): Promise<Readonly<PluginLoadResult>> {
   const result: PluginLoadResult = {
     isValidPlugin: false,
@@ -78,7 +85,7 @@ export default async function loadPlugin(
       result.error = err as Error;
       return result;
     }
-    const localUrl = await getLocalUrl(url, cacheFolder, repoName);
+    const localUrl = await getLocalUrl(url, cacheFolder, repoName, fetchFn);
 
     try {
       module = await import(localUrl);


### PR DESCRIPTION
## Summary
- Adds `FetchCapable`/`FetchInterface` (mirroring the existing `SpawnCapable`/`SpawnInterface` pattern), letting a host CLI framework supply its own `fetch()` implementation (e.g. one integrating timeout/shutdown handling) instead of repositories calling `fetch()` directly.
- `HttpManifestPluginRepository`, `NpmjsPluginRepository` implement `FetchCapable`; `PluginLoader.loadPlugin()`/`getLocalUrl()` accept an optional `fetchFn` parameter.
- `BaseMarketplacePluginManager` implements `FetchCapable` and fans `setFetch()` out to its `remotes`/`local` repositories (and stores it for `HttpPluginManager.installOne()`'s own bundle download).

Part of a cross-repo change also touching `dynamic-cli-framework-api` (new `FetchService`) and `dynamic-cli-framework` (`DefaultFetchService`, `FetchInterfaceAdapter`, wiring into `DefaultPluginServiceProvider`).

## Test plan
- [x] `bun test` - 103 pass
- [x] `bun run build` (tsc) passes
- [x] `bunx oxlint index.ts src/` passes