### PR TITLE
feat!: use config object for NpmPluginRepository and NpmjsPluginRepository constructors

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,8 +24,12 @@ export { default as UrlListPluginRepository } from "./src/plugin_manager/plugin_
 export { default as LocalFolderPluginRepository } from "./src/plugin_manager/plugin_repository/LocalFolderPluginRepository.ts";
 export { default as HttpManifestPluginRepository } from "./src/plugin_manager/plugin_repository/HttpManifestPluginRepository.ts";
 export { default as NpmPluginRepository } from "./src/plugin_manager/plugin_repository/NpmPluginRepository.ts";
+export type { NpmPluginRepositoryConfig } from "./src/plugin_manager/plugin_repository/NpmPluginRepository.ts";
 export { default as NpmjsPluginRepository } from "./src/plugin_manager/plugin_repository/NpmjsPluginRepository.ts";
-export type { NpmSearchQuery } from "./src/plugin_manager/plugin_repository/NpmjsPluginRepository.ts";
+export type {
+  NpmSearchQuery,
+  NpmjsPluginRepositoryConfig,
+} from "./src/plugin_manager/plugin_repository/NpmjsPluginRepository.ts";
 export type { default as MarketplacePluginManager } from "./src/api/plugin_manager/MarketplacePluginManager.ts";
 export { default as BaseMarketplacePluginManager } from "./src/plugin_manager/BaseMarketplacePluginManager.ts";
 export { default as NpmPluginManager } from "./src/plugin_manager/NpmPluginManager.ts";

--- a/src/plugin_manager/plugin_repository/NpmPluginRepository.ts
+++ b/src/plugin_manager/plugin_repository/NpmPluginRepository.ts
@@ -44,6 +44,11 @@ interface PackageJsonNamespaceData {
   pluginData?: Record<string, string>;
 }
 
+export interface NpmPluginRepositoryConfig {
+  nodeModulesPath: string;
+  packageJsonNamespace: string;
+}
+
 /**
  * {@link VersionedPluginRepository} backed by a local `node_modules` directory.
  *
@@ -52,10 +57,13 @@ interface PackageJsonNamespaceData {
  * dependencies, and pluginData. Used as the local installation target by {@link NpmPluginInstaller}.
  */
 export default class NpmPluginRepository implements VersionedPluginRepository {
-  public constructor(
-    public readonly nodeModulesPath: string,
-    public readonly packageJsonNamespace: string,
-  ) {}
+  public readonly nodeModulesPath: string;
+  public readonly packageJsonNamespace: string;
+
+  public constructor(config: NpmPluginRepositoryConfig) {
+    this.nodeModulesPath = config.nodeModulesPath;
+    this.packageJsonNamespace = config.packageJsonNamespace;
+  }
 
   private async *getPluginsAsyncIterable(): AsyncIterable<VersionedPluginDescriptor> {
     let topLevelDirs: string[];

--- a/src/plugin_manager/plugin_repository/NpmjsPluginRepository.ts
+++ b/src/plugin_manager/plugin_repository/NpmjsPluginRepository.ts
@@ -28,6 +28,17 @@ interface NpmPackageMeta {
   pluginData?: Record<string, string>;
 }
 
+export interface NpmjsPluginRepositoryConfig {
+  name: string;
+  description?: string;
+  author?: string;
+  registryUrl: string;
+  packageJsonNamespace: string;
+  authToken?: string;
+  username?: string;
+  password?: string;
+}
+
 /**
  * {@link MarketplacePluginRepository} backed by an npm-compatible registry (e.g. npmjs.com).
  *
@@ -62,16 +73,7 @@ export default class NpmjsPluginRepository implements MarketplacePluginRepositor
     authToken,
     username,
     password,
-  }: {
-    name: string;
-    description?: string;
-    author?: string;
-    registryUrl: string;
-    packageJsonNamespace: string;
-    authToken?: string;
-    username?: string;
-    password?: string;
-  }) {
+  }: NpmjsPluginRepositoryConfig) {
     if (authToken !== undefined && (username !== undefined || password !== undefined)) {
       throw new Error("Cannot specify both authToken and username/password auth");
     }

--- a/tests/plugin_manager/NpmPluginManager_test.ts
+++ b/tests/plugin_manager/NpmPluginManager_test.ts
@@ -147,7 +147,10 @@ describe("NpmPluginManager", () => {
         }),
       );
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo);
 
       // bun remove in a dir without package.json will fail with non-zero exit
@@ -452,7 +455,10 @@ describe("NpmPluginManager", () => {
         }),
       );
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo);
 
       const calls: Array<{ command: ReadonlyArray<string>; cwd: string }> = [];
@@ -474,7 +480,10 @@ describe("NpmPluginManager", () => {
     });
 
     it("throws with the launch error message when the injected SpawnInterface fails to launch", async () => {
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo);
 
       const fakeSpawn: SpawnInterface = {
@@ -486,7 +495,10 @@ describe("NpmPluginManager", () => {
     });
 
     it("throws with the exit code when the injected SpawnInterface exits non-zero", async () => {
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo);
 
       const fakeSpawn: SpawnInterface = {

--- a/tests/plugin_manager/plugin_repository/NpmPluginRepository_test.ts
+++ b/tests/plugin_manager/plugin_repository/NpmPluginRepository_test.ts
@@ -27,7 +27,10 @@ async function writePackageJson(pkgName: string, contents: Record<string, unknow
 describe("NpmPluginRepository Tests", () => {
   describe("getPlugins()", () => {
     it("returns empty when nodeModulesPath does not exist", async () => {
-      const repo = new NpmPluginRepository("/nonexistent/node_modules", NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: "/nonexistent/node_modules",
+        packageJsonNamespace: NAMESPACE,
+      });
       const results: unknown[] = [];
       for await (const d of repo.getPlugins()) {
         results.push(d);
@@ -45,7 +48,10 @@ describe("NpmPluginRepository Tests", () => {
         },
       });
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const results: {
         pluginId: string;
         name: string;
@@ -69,7 +75,10 @@ describe("NpmPluginRepository Tests", () => {
         version: "1.0.0",
       });
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const results: unknown[] = [];
       for await (const d of repo.getPlugins()) {
         results.push(d);
@@ -84,7 +93,10 @@ describe("NpmPluginRepository Tests", () => {
         [NAMESPACE]: { pluginData: { x: "y" } },
       });
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const results: unknown[] = [];
       for await (const d of repo.getPlugins()) {
         results.push(d);
@@ -101,7 +113,10 @@ describe("NpmPluginRepository Tests", () => {
         },
       });
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const results: { pluginId: string; name: string; scope?: string }[] = [];
       for await (const d of repo.getPlugins()) {
         results.push(d);
@@ -125,7 +140,10 @@ describe("NpmPluginRepository Tests", () => {
         [NAMESPACE]: { extensionPoints: ["ep2"] },
       });
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const ids: string[] = [];
       for await (const d of repo.getPlugins()) {
         ids.push(d.pluginId);
@@ -143,7 +161,10 @@ describe("NpmPluginRepository Tests", () => {
         [NAMESPACE]: { extensionPoints: ["ep1"] },
       });
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const result = await repo.getPlugin("my-plugin");
 
       expect(result).toBeDefined();
@@ -152,7 +173,10 @@ describe("NpmPluginRepository Tests", () => {
     });
 
     it("returns undefined for a plugin that is not installed", async () => {
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       expect(await repo.getPlugin("missing-plugin")).toBeUndefined();
     });
 
@@ -163,7 +187,10 @@ describe("NpmPluginRepository Tests", () => {
         [NAMESPACE]: { extensionPoints: ["ep1"] },
       });
 
-      const repo = new NpmPluginRepository(nodeModulesDir, NAMESPACE);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
       const result = await repo.getPlugin("@myscope/scoped-plugin");
 
       expect(result).toBeDefined();


### PR DESCRIPTION
## Summary
- Refactor `NpmPluginRepository`'s constructor from two positional arguments (`nodeModulesPath`, `packageJsonNamespace`) to a single `NpmPluginRepositoryConfig` object, since parameter properties can't be used with a destructured config.
- Extract `NpmjsPluginRepository`'s existing inline constructor parameter type into a named, exported `NpmjsPluginRepositoryConfig` interface (no behavioral change - it already took a config object).
- Export both new interfaces (`NpmPluginRepositoryConfig`, `NpmjsPluginRepositoryConfig`) from the package entry point (`index.ts`).
- Update all constructor call sites in tests to the new object form.

## Breaking change
`NpmPluginRepository`'s constructor signature changed:

```ts
// before
new NpmPluginRepository(nodeModulesPath, packageJsonNamespace);
// after
new NpmPluginRepository({ nodeModulesPath, packageJsonNamespace });
```

`NpmjsPluginRepository`'s runtime behavior and call sites are unchanged (it already took an object); only the type is now named and exported.

This repo's release automation determines the version bump from the commit type, so `feat!:`/`BREAKING CHANGE:` in the commit message (rather than a manual `package.json` edit) is what drives the major-version bump on merge.

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.json` passes
- [x] `bun test` - 103 pass, 0 fail
- [x] `bunx oxlint` - no issues
- [x] `bunx oxfmt --check .` - all files formatted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)