### PR TITLE
fix: inherit stdin when spawning the install command

### DIFF
--- a/src/plugin_manager/NpmPluginManager.ts
+++ b/src/plugin_manager/NpmPluginManager.ts
@@ -99,6 +99,7 @@ export default class NpmPluginManager
 
     const proc = Bun.spawn(resolveForPlatform(args), {
       cwd,
+      stdin: "inherit",
       stdout: "inherit",
       stderr: "inherit",
     });


### PR DESCRIPTION
## Summary
- \`NpmPluginManager.runCommand\` spawns the install command (\`bun add\` / \`npm install\`) via \`Bun.spawn\` without setting \`stdin\`. Bun's default for an unset \`stdin\` is not inherited from the parent process — it's effectively a closed/non-TTY stream.
- When the child needs interactive input (notably bun's "trust dependencies with postinstall scripts?" prompt), the read blocks forever instead of failing or being skipped, hanging \`plugin:add\` indefinitely right after "Resolving dependencies".
- Reported against example-cli's \`plugin:add\` on Windows CI, then reproduced manually on Linux and macOS (1.8.1). Setting \`stdin: "inherit"\` connects the child to the real terminal so any such prompt is answerable (and CI/non-TTY invocations are unaffected, since there's still nothing to inherit there).

## Test plan
- [x] \`bun test\` — 103 pass, 0 fail
- [x] \`tsc -p tsconfig.build.json --noEmit\` — clean
- [x] \`oxlint .\` — clean
- [ ] Manual verification against example-cli's real hang once this is released and the framework dep is bumped (dynamic-plugin-framework has no existing test coverage for interactive-prompt install scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvxRNHoMxUCQwEcuvr8h7G