### PR TITLE
fix: only inherit stdin for the install command on a real TTY

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,17 +5,17 @@
     "": {
       "name": "@flowscripter/dynamic-plugin-framework",
       "dependencies": {
-        "semver": "latest",
+        "semver": "^7.8.5",
       },
       "devDependencies": {
-        "@types/bun": "latest",
-        "@types/node": "latest",
-        "@types/semver": "latest",
-        "oxfmt": "latest",
-        "oxlint": "latest",
+        "@types/bun": "^1.3.14",
+        "@types/node": "^26.1.1",
+        "@types/semver": "^7.7.1",
+        "oxfmt": "0.60.0",
+        "oxlint": "1.75.0",
       },
       "peerDependencies": {
-        "typescript": "latest",
+        "typescript": "^7.0.2",
       },
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -5,17 +5,17 @@
     "": {
       "name": "@flowscripter/dynamic-plugin-framework",
       "dependencies": {
-        "semver": "^7.8.5",
+        "semver": "latest",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.14",
-        "@types/node": "^26.1.1",
-        "@types/semver": "^7.7.1",
-        "oxfmt": "0.60.0",
-        "oxlint": "1.75.0",
+        "@types/bun": "latest",
+        "@types/node": "latest",
+        "@types/semver": "latest",
+        "oxfmt": "latest",
+        "oxlint": "latest",
       },
       "peerDependencies": {
-        "typescript": "^7.0.2",
+        "typescript": "latest",
       },
     },
   },

--- a/src/plugin_manager/NpmPluginManager.ts
+++ b/src/plugin_manager/NpmPluginManager.ts
@@ -99,7 +99,11 @@ export default class NpmPluginManager
 
     const proc = Bun.spawn(resolveForPlatform(args), {
       cwd,
-      stdin: "inherit",
+      // Only inherit stdin when we actually have an interactive terminal to read a
+      // prompt from (e.g. bun's "trust dependencies with postinstall scripts?" prompt).
+      // Inheriting unconditionally hangs non-interactive invocations (CI, piped input)
+      // where the parent's stdin is an open, non-TTY stream that never reaches EOF.
+      stdin: process.stdin.isTTY ? "inherit" : "ignore",
       stdout: "inherit",
       stderr: "inherit",
     });


### PR DESCRIPTION
## Summary
- Fixes a regression introduced by #102. That PR unconditionally set `stdin: "inherit"` on the spawned `bun add`/`npm install` to let bun's interactive trust-dependencies prompt be answered from a real terminal.
- That also inherits stdin for non-interactive invocations (CI, piped input). There the parent's stdin is an open, non-TTY stream that never reaches EOF, so the child blocks reading it - the exact hang #102 was meant to fix, except now it happens *deterministically* on Linux/macOS CI instead of only intermittently on Windows. Caught by flowscripter/example-cli#85 CI run (`test-executable (ubuntu-latest)` timed out at 60s on the `plugin:add` scenario, previously reliable on ubuntu/macOS).
- Fix: only inherit stdin when `process.stdin.isTTY` is true. Otherwise keep it `"ignore"`, matching pre-#102 non-interactive behavior.

## Test plan
- [x] `bun test` — 103 pass, 0 fail
- [x] `tsc -p tsconfig.build.json --noEmit` — clean
- [x] `oxlint .` — clean
- [x] Manual install with `stdin < /dev/null` (non-TTY, matches CI): 3/3 runs complete in ~20ms, no hang
- [ ] Full functional test suite rerun once released and bumped through dynamic-cli-framework/example-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvxRNHoMxUCQwEcuvr8h7G