### PR TITLE
feat: install requested version in NpmPluginManager.installOne

### DIFF
--- a/src/plugin_manager/NpmPluginManager.ts
+++ b/src/plugin_manager/NpmPluginManager.ts
@@ -177,7 +177,11 @@ export default class NpmPluginManager
 
     const cwd = path.dirname(target.nodeModulesPath);
     await mkdir(cwd, { recursive: true });
-    const cmdParts = [...this.installCommand.split(" "), descriptor.pluginId];
+    const installArg =
+      descriptor.version && descriptor.version !== "latest"
+        ? `${descriptor.pluginId}@${descriptor.version}`
+        : descriptor.pluginId;
+    const cmdParts = [...this.installCommand.split(" "), installArg];
     await this.runCommand(cmdParts, cwd);
     await this.validatePluginBundled(descriptor.pluginId, target.nodeModulesPath, cwd);
   }

--- a/tests/plugin_manager/NpmPluginManager_test.ts
+++ b/tests/plugin_manager/NpmPluginManager_test.ts
@@ -133,6 +133,52 @@ describe("NpmPluginManager", () => {
         "not found in any configured remote repository",
       );
     });
+
+    it("appends name@version to the install command when a specific version is requested", async () => {
+      const remote = new MockRemote([makeDescriptor("plugin-a", "3.0.0")]);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
+      const manager = new NpmPluginManager([remote] as unknown as NpmjsPluginRepository[], repo);
+
+      const calls: Array<{ command: ReadonlyArray<string>; cwd: string }> = [];
+      const fakeSpawn: SpawnInterface = {
+        spawn: (command, options) => {
+          calls.push({ command, cwd: options.cwd });
+          return Promise.resolve({ ok: true, exitCode: 0 });
+        },
+      };
+      manager.setSpawn(fakeSpawn);
+
+      await manager.install(makeDescriptor("plugin-a", "3.0.0"));
+
+      expect(calls[0].command).toContain("plugin-a@3.0.0");
+      expect(calls[0].command).not.toContain("plugin-a");
+    });
+
+    it("installs the bare pluginId when version is 'latest'", async () => {
+      const remote = new MockRemote([makeDescriptor("plugin-a", "latest")]);
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
+      const manager = new NpmPluginManager([remote] as unknown as NpmjsPluginRepository[], repo);
+
+      const calls: Array<{ command: ReadonlyArray<string>; cwd: string }> = [];
+      const fakeSpawn: SpawnInterface = {
+        spawn: (command, options) => {
+          calls.push({ command, cwd: options.cwd });
+          return Promise.resolve({ ok: true, exitCode: 0 });
+        },
+      };
+      manager.setSpawn(fakeSpawn);
+
+      await manager.install(makeDescriptor("plugin-a", "latest"));
+
+      expect(calls[0].command).toContain("plugin-a");
+      expect(calls[0].command).not.toContain("plugin-a@latest");
+    });
   });
 
   describe("uninstall()", () => {


### PR DESCRIPTION
## Summary

`NpmPluginManager.installOne()` only ever appended `descriptor.pluginId` (bare, unversioned) to the install command - `descriptor.version` was read into the descriptor but never actually used when constructing the `bun add`/`npm install` invocation. Any explicitly requested version silently resolved to whatever the package manager picks by default (latest).

This change constructs the install argument as `` `${descriptor.pluginId}@${descriptor.version}` `` when `descriptor.version` is set and is not `"latest"`, falling back to the bare `pluginId` otherwise (unchanged behavior for the common no-version-requested case).

## Context

This is the second half of the fix for flowscripter/dynamic-cli-framework#147 ("Support version in plugin add command"). The companion PR flowscripter/dynamic-cli-framework#154 adds specifier parsing (`@scope/name:3.0.0` -> `{ pluginId, version }`) in `dynamic-cli-framework`'s `PluginAddSubCommand`, threading the parsed version into the `VersionedPluginDescriptor` passed to `install()`. That parsing was already reaching `descriptor.version`, but without this fix the version was silently dropped at install time.

`dynamic-cli-framework` depends on a published version of `@flowscripter/dynamic-plugin-framework` (currently pinned, not a workspace link), so **this PR needs to be merged and released before flowscripter/dynamic-cli-framework#154's version-specifier support works end-to-end** - until then, an explicit version in `plugin:add @scope/name:3.0.0` will parse correctly but still install latest.

## Test plan

- [x] `bun test` - all 105 tests pass, including two new cases: appends `name@version` when a specific version is requested, and installs the bare name when version is `"latest"`
- [x] `bunx oxlint index.ts plugin.ts src/ tests/` - clean
- [x] `bunx oxfmt --check index.ts plugin.ts src/ tests/` - clean
- [x] `bunx tsc --noEmit` - clean

<!-- flowscripter-agent:v1 -->