### PR TITLE
fix: pipe and forward install command output instead of inheriting handles

### DIFF
--- a/src/plugin_manager/NpmPluginManager.ts
+++ b/src/plugin_manager/NpmPluginManager.ts
@@ -31,6 +31,18 @@ export function resolveForPlatform(args: string[]): string[] {
   return ["cmd.exe", "/d", "/s", "/c", resolved, ...rest];
 }
 
+async function pumpToStdout(stream: ReadableStream<Uint8Array>): Promise<void> {
+  for await (const chunk of stream) {
+    process.stdout.write(chunk);
+  }
+}
+
+async function pumpToStderr(stream: ReadableStream<Uint8Array>): Promise<void> {
+  for await (const chunk of stream) {
+    process.stderr.write(chunk);
+  }
+}
+
 /**
  * {@link BaseMarketplacePluginManager} for the npm ecosystem.
  *
@@ -104,10 +116,22 @@ export default class NpmPluginManager
       // Inheriting unconditionally hangs non-interactive invocations (CI, piped input)
       // where the parent's stdin is an open, non-TTY stream that never reaches EOF.
       stdin: process.stdin.isTTY ? "inherit" : "ignore",
-      stdout: "inherit",
-      stderr: "inherit",
+      // "pipe" rather than "inherit": on Windows, "inherit" hands the child our own
+      // stdout/stderr OS handles, which get duplicated again into every process it
+      // spawns (cmd.exe -> bun.exe -> further helper processes). If any of those
+      // grandchildren doesn't close its copy promptly, a caller reading our output
+      // (e.g. Python's subprocess.communicate()) can block past the point where the
+      // whole visible process tree has already exited. "pipe" gives Bun its own
+      // dedicated pipe that never leaves this process, so we forward bytes ourselves
+      // instead of sharing the caller's handle down an uncontrolled process chain.
+      stdout: "pipe",
+      stderr: "pipe",
     });
-    const exitCode = await proc.exited;
+    const [, , exitCode] = await Promise.all([
+      pumpToStdout(proc.stdout),
+      pumpToStderr(proc.stderr),
+      proc.exited,
+    ]);
     if (exitCode !== 0) {
       throw new Error(`Command '${args.join(" ")}' failed with exit code ${exitCode}`);
     }


### PR DESCRIPTION
## Summary
- Fixes the pre-existing, Windows-only `plugin:add` hang (predates #102/#103, and recurred after them — see flowscripter/example-cli#86, CI runs 30626999894, jobs 91144471378 and 91152776252).
- Both failing runs show the same signature: at the 60s timeout, the CI diagnostic process-list dump has **no `executable.exe`, `bun.exe`, `cmd.exe`, or `node.exe`** anywhere — the whole process tree we spawned has already exited — yet the test harness's read of our stdout/stderr never reaches EOF.
- Root cause: `stdout`/`stderr: "inherit"` hands the child our own OS-level output handles. On Windows these get duplicated into every process the child spawns in turn (`cmd.exe` -> `bun.exe` -> further helper processes for extraction/lifecycle scripts). If any of those grandchildren doesn't close its copy of the handle promptly on exit, a caller reading our output (e.g. Python's `subprocess.communicate()`) can block indefinitely, even after everything we can see has terminated, because the handle traces all the way back through our process to theirs.
- Fix: switch to `"pipe"` and forward chunks ourselves via `process.stdout`/`process.stderr`. This gives Bun a dedicated pipe scoped to this one spawn call that never leaves our process, so a handle leak several hops down the bun/cmd/node chain can no longer keep the *caller's* pipe open past our own exit.

## Test plan
- [x] `bun test` — 105 pass, 0 fail
- [x] `tsc -p tsconfig.build.json --noEmit` — clean
- [x] `oxlint .` — clean
- [x] 13/15 manual installs against the real registry (non-TTY, matching CI) complete in ~1s; the two anomalies were a cold-cache network stall during dependency resolution (before any process spawning) and registry rate-limiting from the repeated test loop — neither related to this change
- [ ] Can't reproduce the underlying Windows handle-inheritance bug in this environment (Linux) — needs a green run on `windows-latest` CI once released and bumped through dynamic-cli-framework/example-cli to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvxRNHoMxUCQwEcuvr8h7G