### PR TITLE
feat: add checkAvailable to MarketplacePluginManager

### DIFF
--- a/src/api/plugin_manager/MarketplacePluginManager.ts
+++ b/src/api/plugin_manager/MarketplacePluginManager.ts
@@ -50,6 +50,28 @@ export default interface MarketplacePluginManager extends PluginManager {
   listInstalled(): AsyncIterable<Readonly<VersionedPluginDescriptor>>;
 
   /**
+   * Check whether a plugin (and, optionally, a specific version of it) is available from any of
+   * the configured remote marketplace repositories, via a direct targeted lookup - not the
+   * fuzzy/ranked {@link search}.
+   *
+   * Each remote is checked in order via its {@link MarketplacePluginRepository.getPlugin}, which
+   * performs a targeted lookup rather than scanning all plugins. Returns `true` as soon as any
+   * remote has a match.
+   *
+   * Note: a `MarketplacePluginRepository` exposes a single "current" {@link VersionedPluginDescriptor}
+   * per plugin ID (typically the latest published version), not a full version history. When
+   * `version` is given, this checks whether that current version matches - it does not confirm
+   * whether an older version was ever published.
+   *
+   * @param pluginId the plugin ID to check for (as returned by {@link VersionedPluginDescriptor.pluginId}).
+   * @param version optional exact version to additionally check for.
+   *
+   * @return `true` if the plugin (and version, if given) is found in at least one configured remote,
+   * `false` otherwise.
+   */
+  checkAvailable(pluginId: string, version?: string): Promise<boolean>;
+
+  /**
    * Compare the local repository against a remote repository and yield entries where a newer
    * version is available remotely.
    *

--- a/src/plugin_manager/BaseMarketplacePluginManager.ts
+++ b/src/plugin_manager/BaseMarketplacePluginManager.ts
@@ -85,6 +85,16 @@ export default abstract class BaseMarketplacePluginManager<
 
   public abstract uninstall(pluginId: string): Promise<void>;
 
+  public async checkAvailable(pluginId: string, version?: string): Promise<boolean> {
+    for (const remote of this.remotes) {
+      const descriptor = await remote.getPlugin(pluginId);
+      if (descriptor && (version === undefined || descriptor.version === version)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private async *checkForUpdatesIterable(
     remote: VersionedPluginRepository,
   ): AsyncIterable<{ descriptor: Readonly<VersionedPluginDescriptor>; availableVersion: string }> {

--- a/tests/plugin_manager/HttpPluginManager_test.ts
+++ b/tests/plugin_manager/HttpPluginManager_test.ts
@@ -263,6 +263,70 @@ describe("HttpPluginManager", () => {
     });
   });
 
+  describe("checkAvailable()", () => {
+    it("returns true when the plugin is found on the first remote", async () => {
+      const remote1 = new MockRemote([makeDescriptor("my-plugin", "1.0.0", "my-plugin")]);
+      const remote2 = new MockRemote([]);
+      const manager = new HttpPluginManager(
+        [remote1, remote2] as unknown as HttpManifestPluginRepository[],
+        new MockLocal() as unknown as LocalFolderPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin")).toEqual(true);
+    });
+
+    it("returns true when the plugin is found on a later remote after an earlier miss", async () => {
+      const remote1 = new MockRemote([]);
+      const remote2 = new MockRemote([makeDescriptor("my-plugin", "1.0.0", "my-plugin")]);
+      const manager = new HttpPluginManager(
+        [remote1, remote2] as unknown as HttpManifestPluginRepository[],
+        new MockLocal() as unknown as LocalFolderPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin")).toEqual(true);
+    });
+
+    it("returns false when the plugin is not found on any remote", async () => {
+      const remote1 = new MockRemote([makeDescriptor("other-plugin")]);
+      const remote2 = new MockRemote([]);
+      const manager = new HttpPluginManager(
+        [remote1, remote2] as unknown as HttpManifestPluginRepository[],
+        new MockLocal() as unknown as LocalFolderPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin")).toEqual(false);
+    });
+
+    it("returns false when no remotes are configured", async () => {
+      const manager = new HttpPluginManager(
+        [] as unknown as HttpManifestPluginRepository[],
+        new MockLocal() as unknown as LocalFolderPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin")).toEqual(false);
+    });
+
+    it("returns true when the requested version matches the remote's current version", async () => {
+      const remote = new MockRemote([makeDescriptor("my-plugin", "1.2.3", "my-plugin")]);
+      const manager = new HttpPluginManager(
+        [remote] as unknown as HttpManifestPluginRepository[],
+        new MockLocal() as unknown as LocalFolderPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin", "1.2.3")).toEqual(true);
+    });
+
+    it("returns false when the requested version does not match the remote's current version", async () => {
+      const remote = new MockRemote([makeDescriptor("my-plugin", "1.2.3", "my-plugin")]);
+      const manager = new HttpPluginManager(
+        [remote] as unknown as HttpManifestPluginRepository[],
+        new MockLocal() as unknown as LocalFolderPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin", "9.9.9")).toEqual(false);
+    });
+  });
+
   describe("registerExtensions() / getRegisteredExtensions()", () => {
     it("returns empty array for unregistered extension point after registerExtensions", async () => {
       const manager = new HttpPluginManager(

--- a/tests/plugin_manager/NpmPluginManager_test.ts
+++ b/tests/plugin_manager/NpmPluginManager_test.ts
@@ -299,6 +299,70 @@ describe("NpmPluginManager", () => {
     });
   });
 
+  describe("checkAvailable()", () => {
+    it("returns true when the plugin is found on the first remote", async () => {
+      const remote1 = new MockRemote([makeDescriptor("my-plugin", "1.0.0", "my-plugin")]);
+      const remote2 = new MockRemote([]);
+      const manager = new NpmPluginManager(
+        [remote1, remote2] as unknown as NpmjsPluginRepository[],
+        new MockLocal() as unknown as NpmPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin")).toEqual(true);
+    });
+
+    it("returns true when the plugin is found on a later remote after an earlier miss", async () => {
+      const remote1 = new MockRemote([]);
+      const remote2 = new MockRemote([makeDescriptor("my-plugin", "1.0.0", "my-plugin")]);
+      const manager = new NpmPluginManager(
+        [remote1, remote2] as unknown as NpmjsPluginRepository[],
+        new MockLocal() as unknown as NpmPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin")).toEqual(true);
+    });
+
+    it("returns false when the plugin is not found on any remote", async () => {
+      const remote1 = new MockRemote([makeDescriptor("other-plugin")]);
+      const remote2 = new MockRemote([]);
+      const manager = new NpmPluginManager(
+        [remote1, remote2] as unknown as NpmjsPluginRepository[],
+        new MockLocal() as unknown as NpmPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin")).toEqual(false);
+    });
+
+    it("returns false when no remotes are configured", async () => {
+      const manager = new NpmPluginManager(
+        [] as unknown as NpmjsPluginRepository[],
+        new MockLocal() as unknown as NpmPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin")).toEqual(false);
+    });
+
+    it("returns true when the requested version matches the remote's current version", async () => {
+      const remote = new MockRemote([makeDescriptor("my-plugin", "1.2.3", "my-plugin")]);
+      const manager = new NpmPluginManager(
+        [remote] as unknown as NpmjsPluginRepository[],
+        new MockLocal() as unknown as NpmPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin", "1.2.3")).toEqual(true);
+    });
+
+    it("returns false when the requested version does not match the remote's current version", async () => {
+      const remote = new MockRemote([makeDescriptor("my-plugin", "1.2.3", "my-plugin")]);
+      const manager = new NpmPluginManager(
+        [remote] as unknown as NpmjsPluginRepository[],
+        new MockLocal() as unknown as NpmPluginRepository,
+      );
+
+      expect(await manager.checkAvailable("my-plugin", "9.9.9")).toEqual(false);
+    });
+  });
+
   describe("registerExtensions() / getRegisteredExtensions()", () => {
     it("returns empty array for unregistered extension point after registerExtensions", async () => {
       const manager = new NpmPluginManager(


### PR DESCRIPTION
## Summary

Adds `checkAvailable(pluginId: string, version?: string): Promise<boolean>` to the `MarketplacePluginManager` interface, so callers can confirm a plugin (and optionally a specific version) exists on a configured remote via a direct, targeted lookup - not the fuzzy/ranked `search()`.

Implemented once, generically, in `BaseMarketplacePluginManager` (shared by both `NpmPluginManager` and `HttpPluginManager`): iterates `this.remotes` in order and calls each remote's existing `MarketplacePluginRepository.getPlugin(pluginId)` (already documented as a "targeted lookup" contract, and already used by `checkForUpdates`), returning `true` as soon as any remote has a match. When `version` is given, it's compared against the descriptor's current version - marketplace repositories in this framework expose a single current version per plugin (not a full version history), consistent with how `search`/`checkForUpdates` already model plugins.

This is stage 1 of a three-repo rework requested on flowscripter/dynamic-cli-framework#147, replacing a duck-typed `assertPluginAvailable` workaround that had been added directly to `DefaultPluginService` in `dynamic-cli-framework` (PR #160) instead of going through proper interface layers:

1. **This PR**: `checkAvailable` on `MarketplacePluginManager` (dynamic-plugin-framework)
2. Next: `checkAvailable` on `PluginService` (dynamic-cli-framework-api), once this releases
3. Then: rewire `DefaultPluginService`/`PluginAddSubCommand` in dynamic-cli-framework to call the properly-typed method, removing the duck-typing workaround

Refs flowscripter/dynamic-cli-framework#147

## Test plan

- [x] `bun test` - 117 pass, 0 fail (including 12 new `checkAvailable()` tests across `NpmPluginManager_test.ts` and `HttpPluginManager_test.ts`: found-on-first-remote, found-on-later-remote-after-a-miss, not-found-anywhere, no-remotes-configured, version-match, version-mismatch)
- [x] `bunx oxfmt` - no diff
- [x] `bunx oxlint index.ts plugin.ts src/ tests/` - clean
- [x] `bunx tsc --noEmit` - clean

<!-- flowscripter-agent:v1 -->