### PR TITLE
fix: apply timeout to plugin install spawn to prevent indefinite hangs

### DIFF
--- a/src/api/spawn/SpawnInterface.ts
+++ b/src/api/spawn/SpawnInterface.ts
@@ -3,12 +3,14 @@
  *
  * `ok` is `true` only when the process launched and exited with code `0`. A launch failure (e.g.
  * the binary was not found) sets `error` with no `exitCode`; a non-zero exit sets `exitCode` with
- * no `error`.
+ * no `error`; a process that did not exit within `options.timeoutMs` sets `timedOut` with no
+ * `error`/`exitCode`.
  */
 export interface SpawnResult {
   ok: boolean;
   exitCode?: number;
   error?: Error;
+  timedOut?: boolean;
 }
 
 /**
@@ -22,8 +24,13 @@ export default interface SpawnInterface {
    *
    * @param command the command and its arguments, e.g. `["bun", "add", "some-package"]`.
    * @param options.cwd the working directory for the spawned process.
+   * @param options.timeoutMs if specified, the process is killed and {@link SpawnResult.timedOut}
+   * is set if it has not exited within this many milliseconds. Defaults to unbounded.
    *
    * @return the {@link SpawnResult}. Never rejects.
    */
-  spawn(command: ReadonlyArray<string>, options: { cwd: string }): Promise<SpawnResult>;
+  spawn(
+    command: ReadonlyArray<string>,
+    options: { cwd: string; timeoutMs?: number },
+  ): Promise<SpawnResult>;
 }

--- a/src/plugin_manager/NpmPluginManager.ts
+++ b/src/plugin_manager/NpmPluginManager.ts
@@ -31,6 +31,17 @@ export function resolveForPlatform(args: string[]): string[] {
   return ["cmd.exe", "/d", "/s", "/c", resolved, ...rest];
 }
 
+/**
+ * Default timeout applied to an install/uninstall command spawn.
+ *
+ * Resolving and downloading a dependency tree can legitimately take a while on a slow
+ * connection, so this is generous compared to the registry pre-check timeout used by
+ * `checkAvailable()` (10s, see `defaultFetch.ts`'s `DEFAULT_FETCH_TIMEOUT_MS`) - but it must
+ * still be bounded so a stalled network connection during the package manager's own registry
+ * access fails with a clear error instead of hanging the calling process indefinitely.
+ */
+export const DEFAULT_INSTALL_TIMEOUT_MS = 120_000;
+
 async function pumpToStdout(stream: ReadableStream<Uint8Array>): Promise<void> {
   for await (const chunk of stream) {
     process.stdout.write(chunk);
@@ -56,6 +67,7 @@ export default class NpmPluginManager
   implements SpawnCapable
 {
   private readonly installCommand: string;
+  private readonly installTimeoutMs: number;
   private spawn: SpawnInterface | undefined;
 
   /**
@@ -66,6 +78,8 @@ export default class NpmPluginManager
    * `npm` is on `PATH` instead. Throws if neither is found and no explicit command is given.
    * @param options.pluginManager optional {@link PluginManager} to delegate to; see
    * {@link BaseMarketplacePluginManager}.
+   * @param options.installTimeoutMs optional timeout applied to each install/uninstall command
+   * spawn; defaults to {@link DEFAULT_INSTALL_TIMEOUT_MS}.
    */
   public constructor(
     remotes: NpmjsPluginRepository[],
@@ -73,10 +87,12 @@ export default class NpmPluginManager
     {
       installCommand,
       pluginManager,
-    }: { installCommand?: string; pluginManager?: PluginManager } = {},
+      installTimeoutMs,
+    }: { installCommand?: string; pluginManager?: PluginManager; installTimeoutMs?: number } = {},
   ) {
     super(remotes, local, pluginManager);
     this.installCommand = installCommand ?? NpmPluginManager.resolveDefaultInstallCommand();
+    this.installTimeoutMs = installTimeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
     const binary = this.installCommand.split(" ")[0]!;
     if (!Bun.which(binary)) {
       throw new Error(
@@ -99,8 +115,11 @@ export default class NpmPluginManager
 
   private async runCommand(args: string[], cwd: string): Promise<void> {
     if (this.spawn) {
-      const result = await this.spawn.spawn(args, { cwd });
+      const result = await this.spawn.spawn(args, { cwd, timeoutMs: this.installTimeoutMs });
       if (!result.ok) {
+        if (result.timedOut) {
+          throw new Error(`Command '${args.join(" ")}' timed out after ${this.installTimeoutMs}ms`);
+        }
         if (result.error) {
           throw new Error(`Command '${args.join(" ")}' failed to launch: ${result.error.message}`);
         }
@@ -127,11 +146,32 @@ export default class NpmPluginManager
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [, , exitCode] = await Promise.all([
-      pumpToStdout(proc.stdout),
-      pumpToStderr(proc.stderr),
-      proc.exited,
-    ]);
+
+    // No injected SpawnInterface to enforce a timeout for us here, so do it manually: a plain
+    // setTimeout()/proc.kill() rather than AbortSignal.timeout() for the same cross-platform
+    // portability reasons as defaultFetch.ts's timeout (established Bun-on-Windows unreliability
+    // during the earlier fetch-timeout investigation). The timer is always cleared once the
+    // process exits so no dangling timer is left behind.
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, this.installTimeoutMs);
+
+    let exitCode: number;
+    try {
+      [, , exitCode] = await Promise.all([
+        pumpToStdout(proc.stdout),
+        pumpToStderr(proc.stderr),
+        proc.exited,
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (timedOut) {
+      throw new Error(`Command '${args.join(" ")}' timed out after ${this.installTimeoutMs}ms`);
+    }
     if (exitCode !== 0) {
       throw new Error(`Command '${args.join(" ")}' failed with exit code ${exitCode}`);
     }

--- a/tests/plugin_manager/NpmPluginManager_test.ts
+++ b/tests/plugin_manager/NpmPluginManager_test.ts
@@ -618,5 +618,80 @@ describe("NpmPluginManager", () => {
 
       await expect(manager.uninstall("my-plugin")).rejects.toThrow("failed with exit code 7");
     });
+
+    it("passes installTimeoutMs through to the injected SpawnInterface", async () => {
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
+      const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo, {
+        installTimeoutMs: 5_000,
+      });
+
+      const calls: Array<{ timeoutMs: number | undefined }> = [];
+      const fakeSpawn: SpawnInterface = {
+        spawn: (_command, options) => {
+          calls.push({ timeoutMs: options.timeoutMs });
+          return Promise.resolve({ ok: true, exitCode: 0 });
+        },
+      };
+      manager.setSpawn(fakeSpawn);
+
+      await manager.uninstall("my-plugin");
+
+      expect(calls[0].timeoutMs).toEqual(5_000);
+    });
+
+    it("throws a clear timeout error when the injected SpawnInterface reports timedOut", async () => {
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
+      const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo, {
+        installTimeoutMs: 5_000,
+      });
+
+      const fakeSpawn: SpawnInterface = {
+        spawn: () => Promise.resolve({ ok: false, timedOut: true }),
+      };
+      manager.setSpawn(fakeSpawn);
+
+      await expect(manager.uninstall("my-plugin")).rejects.toThrow("timed out after 5000ms");
+    });
+  });
+
+  describe("raw Bun.spawn fallback timeout (no injected SpawnInterface)", () => {
+    it("completes normally when the command finishes within installTimeoutMs", async () => {
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
+      const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo, {
+        installCommand: `${process.execPath} -e`,
+        installTimeoutMs: 10_000,
+      });
+
+      // installCommand's binary is process.execPath, so the "package" arg becomes an inline
+      // script that exits immediately - exercises the real Bun.spawn path without hanging.
+      await expect(manager.uninstall('console.log("noop")')).resolves.toBeUndefined();
+    });
+
+    it("kills a hanging command and throws a clear timeout error instead of hanging forever", async () => {
+      const repo = new NpmPluginRepository({
+        nodeModulesPath: nodeModulesDir,
+        packageJsonNamespace: NAMESPACE,
+      });
+      const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo, {
+        installCommand: `${process.execPath} -e`,
+        installTimeoutMs: 50,
+      });
+
+      // Deliberately hangs forever - exercises the timeout kill path. A short installTimeoutMs
+      // (50ms) keeps this test fast; if the timeout mechanism were broken this test would hang
+      // rather than fail cleanly.
+      await expect(manager.uninstall("await new Promise(() => {})")).rejects.toThrow(
+        "timed out after 50ms",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

The registry pre-check fetch timeout fixed in #107 (released as 2.2.1) addressed *one* cause of `plugin:add` hanging on Windows, but not the actual install-spawn step. `NpmPluginManager.runCommand()` has two code paths and both had gaps:

1. **Injected `SpawnInterface`** (the normal case when running inside a host CLI): called `this.spawn.spawn(args, { cwd })` without ever passing `timeoutMs`, even though the underlying `SpawnService` in `dynamic-cli-framework-api` has supported a real `timeoutMs` option all along - nothing in this repo's own `SpawnInterface` type exposed it, so there was nothing to plumb through.
2. **Raw `Bun.spawn()` fallback** (no `SpawnInterface` injected, e.g. standalone usage): had zero timeout protection. If the spawned `bun add`/`npm install` process hung (e.g. on a stalled connection during its own registry access), this would wait forever.

## Changes

- `src/api/spawn/SpawnInterface.ts`: added an optional `timeoutMs` to `spawn()`'s options and a `timedOut` flag to `SpawnResult`, matching the shape already supported by `dynamic-cli-framework-api`'s `SpawnService`.
- `src/plugin_manager/NpmPluginManager.ts`:
  - Path 1 now passes `timeoutMs` to the injected `SpawnInterface` and throws a clear `Command '...' timed out after Nms` error when `result.timedOut` is set.
  - Path 2 (raw `Bun.spawn()`) now applies the same timeout manually via `setTimeout()` + `proc.kill()`, cleared in a `finally` once the process exits - deliberately avoiding `AbortSignal.timeout()` given the Bun-on-Windows unreliability found during the earlier fetch-timeout investigation (#107), mirroring `defaultFetch.ts`'s approach.
  - Default timeout is `DEFAULT_INSTALL_TIMEOUT_MS = 120_000` (generous vs. the 10s registry pre-check timeout, since dependency resolution/download can legitimately take a while), configurable via a new `installTimeoutMs` constructor option.
- Searched the repo for other `Bun.spawn`/`this.spawn.spawn` call sites - this is the only one.

## Test plan

- [x] New tests in `tests/plugin_manager/NpmPluginManager_test.ts`: `timeoutMs` is passed through to an injected `SpawnInterface`; a `timedOut` result surfaces a clear error; the raw `Bun.spawn()` fallback completes normally within the timeout; a genuinely hanging raw spawn is killed and throws a clear timeout error (short `installTimeoutMs` used so the test itself completes in ~50ms, not 120s).
- [x] `bun test` - 125 pass, 0 fail (239ms total, hang test confirmed non-hanging)
- [x] `bunx tsc --noEmit` - clean
- [x] `bunx oxlint index.ts plugin.ts src/ tests/` - clean
- [x] `bunx oxfmt --check index.ts plugin.ts src/ tests/` - clean

Refs dynamic-cli-framework#147

<!-- flowscripter-agent:v1 -->