### PR TITLE
fix: seed package.json in plugin install dir to stop bun installing into an ancestor dir

### DIFF
--- a/src/plugin_manager/NpmPluginManager.ts
+++ b/src/plugin_manager/NpmPluginManager.ts
@@ -113,6 +113,22 @@ export default class NpmPluginManager
     this.spawn = spawn;
   }
 
+  /**
+   * Ensures `cwd` has its own `package.json` before an install/uninstall command is run there.
+   *
+   * Without one, `bun add`/`bun remove` (and npm, under workspace configs) walk UP the
+   * directory tree looking for an ancestor `package.json` and, if found, treat that
+   * ancestor as the install root - silently installing into the ancestor's `node_modules`
+   * instead of `cwd`, while still exiting 0. Seeding an empty `package.json` in `cwd` first
+   * makes `cwd` itself the install root, regardless of what exists further up the tree.
+   */
+  private async ensurePackageJson(cwd: string): Promise<void> {
+    const pkgJsonPath = path.join(cwd, "package.json");
+    const pkgFile = Bun.file(pkgJsonPath);
+    if (await pkgFile.exists()) return;
+    await Bun.write(pkgJsonPath, JSON.stringify({ name: "plugins", private: true }, null, 2));
+  }
+
   private async runCommand(args: string[], cwd: string): Promise<void> {
     if (this.spawn) {
       const result = await this.spawn.spawn(args, { cwd, timeoutMs: this.installTimeoutMs });
@@ -241,6 +257,7 @@ export default class NpmPluginManager
 
     const cwd = path.dirname(target.nodeModulesPath);
     await mkdir(cwd, { recursive: true });
+    await this.ensurePackageJson(cwd);
     const installArg =
       descriptor.version && descriptor.version !== "latest"
         ? `${descriptor.pluginId}@${descriptor.version}`
@@ -299,6 +316,7 @@ export default class NpmPluginManager
 
     const cwd = path.dirname(this.local.nodeModulesPath);
     await mkdir(cwd, { recursive: true });
+    await this.ensurePackageJson(cwd);
     let removeCmd: string;
     if (this.installCommand.startsWith("bun")) {
       removeCmd = "bun remove";

--- a/tests/plugin_manager/NpmPluginManager_test.ts
+++ b/tests/plugin_manager/NpmPluginManager_test.ts
@@ -183,25 +183,76 @@ describe("NpmPluginManager", () => {
 
   describe("uninstall()", () => {
     it("throws when the remove command fails", async () => {
-      await mkdir(path.join(nodeModulesDir, "my-plugin"), { recursive: true });
-      await Bun.write(
-        path.join(nodeModulesDir, "my-plugin", "package.json"),
-        JSON.stringify({
-          name: "my-plugin",
-          version: "1.0.0",
-          [NAMESPACE]: { extensionPoints: ["ep1"] },
-        }),
-      );
-
       const repo = new NpmPluginRepository({
         nodeModulesPath: nodeModulesDir,
         packageJsonNamespace: NAMESPACE,
       });
       const manager = new NpmPluginManager([] as unknown as NpmjsPluginRepository[], repo);
 
-      // bun remove in a dir without package.json will fail with non-zero exit
-      await expect(manager.uninstall("my-plugin")).rejects.toThrow();
+      // an unrecognised dependency specifier makes real `bun remove` exit non-zero
+      // regardless of package.json/node_modules state.
+      await expect(manager.uninstall("not a valid package name!!")).rejects.toThrow();
     });
+  });
+
+  describe("ancestor package.json regression (real bun spawn)", () => {
+    it(
+      "installs into the plugin repository's own directory, not an ancestor's, when an " +
+        "ancestor package.json exists above it",
+      async () => {
+        // Regression test for https://github.com/flowscripter/dynamic-cli-framework/issues/166:
+        // without its own package.json, `bun add` walks UP the directory tree, finds the
+        // ancestor's package.json, and installs there instead of into `cwd` - while still
+        // exiting 0. Uses a real (non-mocked) spawn of the actual `bun` binary, and a local
+        // file-path "package" instead of a registry package, so this stays network-free.
+        const root = await mkdtemp(path.join(tmpdir(), "npm-manager-ancestor-test-"));
+        try {
+          await Bun.write(
+            path.join(root, "package.json"),
+            JSON.stringify({ name: "ancestor", version: "1.0.0" }),
+          );
+
+          const fixturePkgDir = path.join(root, "fixture-pkg");
+          await mkdir(fixturePkgDir, { recursive: true });
+          await Bun.write(
+            path.join(fixturePkgDir, "package.json"),
+            JSON.stringify({ name: "fixture-pkg", version: "1.0.0", main: "index.js" }),
+          );
+          await Bun.write(path.join(fixturePkgDir, "index.js"), "module.exports = 1;\n");
+
+          // Deliberately nested below `root` with no package.json of its own, and not
+          // pre-created - installOne() must create it.
+          const nodeModulesPath = path.join(root, "nested", "plugins", "node_modules");
+
+          const repo = new NpmPluginRepository({
+            nodeModulesPath,
+            packageJsonNamespace: NAMESPACE,
+          });
+          const descriptor = makeDescriptor(fixturePkgDir, "latest");
+          const remote = new MockRemote([descriptor]);
+          const manager = new NpmPluginManager(
+            [remote] as unknown as NpmjsPluginRepository[],
+            repo,
+          );
+          // no setSpawn(): exercises the real Bun.spawn("bun", "add", ...) path.
+
+          await manager.install(descriptor);
+
+          const installedAtTarget = await Bun.file(
+            path.join(nodeModulesPath, "fixture-pkg", "package.json"),
+          ).exists();
+          expect(installedAtTarget).toBe(true);
+
+          const installedAtAncestor = await Bun.file(
+            path.join(root, "node_modules", "fixture-pkg", "package.json"),
+          ).exists();
+          expect(installedAtAncestor).toBe(false);
+        } finally {
+          await rm(root, { recursive: true, force: true });
+        }
+      },
+      30000,
+    );
   });
 
   describe("checkForUpdates()", () => {


### PR DESCRIPTION
## Summary

`bun add`/`bun remove` walk UP the directory tree looking for a `package.json` when the target directory doesn't have its own. If an ancestor directory (e.g. the user's home directory, or any parent of `~/.examplecli/plugins`) has a `package.json`, bun treats that ancestor as the install root and installs there instead - into the ancestor's `node_modules` - while still exiting 0. `NpmPluginManager` only checked the spawn exit code, so `plugin:add` reported success even though the plugin landed in the wrong place and `plugin:list` (which only scans the intended `node_modules`) found nothing.

Root-caused with a real (non-mocked) `bun add` spawn against a temp directory tree with an ancestor `package.json`: with no `package.json` in the target dir, the package lands in the ancestor's `node_modules`; pre-seeding a minimal `package.json` in the target dir makes bun treat that dir as its own install root, matching correct behavior.

- `installOne()`/`uninstall()` in `NpmPluginManager` now call a new `ensurePackageJson(cwd)` that writes a minimal `{ name: "plugins", private: true }` package.json into the target directory (only if one doesn't already exist) before running the install/uninstall command.
- Updated `uninstall()`'s "throws when the remove command fails" test, since it previously relied on the target directory lacking a package.json to force a real `bun remove` failure - that's exactly the condition being fixed. It now uses a malformed dependency specifier to still exercise a real failing spawn.
- Added a regression test that reproduces the original bug end-to-end with a real (non-mocked) `bun add` spawn against a temp directory tree containing an ancestor `package.json`, and asserts the package lands in the plugin repository's own directory rather than the ancestor's. Uses a local file-path "package" instead of a registry package so it stays network-free.

Refs flowscripter/dynamic-cli-framework#166

## Test plan

- [x] `bun test` - 126 pass, 0 fail (includes new regression test using a real `bun add` spawn)
- [x] `bunx oxlint index.ts plugin.ts src/ tests/` - clean
- [x] `bunx oxfmt --check .` - clean
- [x] `bunx tsc --noEmit` - clean
- [x] Manually reproduced the bug and the fix outside the test suite with real `bun add` spawns in temp directory trees

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1nPLbiXvGgZoKbkutfQvD